### PR TITLE
Increase Option size from 128 char to 256

### DIFF
--- a/src/Element/WebformOptions.php
+++ b/src/Element/WebformOptions.php
@@ -100,6 +100,7 @@ class WebformOptions extends FormElement {
             '#title' => t('Option text'),
             '#title_display' => t('invisible'),
             '#placeholder' => t('Enter text'),
+            '#maxlength' => 256,
           ],
         ],
         '#default_value' => (isset($element['#default_value'])) ? self::convertOptionsToValues($element['#default_value']) : [],


### PR DESCRIPTION
Options for Radios buttons have the limited size of 128. It's sometimes too short (especially when you want to add some HTML code in the option text such as links) 