### PR TITLE
Error: HTML emails are shown with escaped tags

### DIFF
--- a/src/Plugin/WebformHandler/EmailWebformHandler.php
+++ b/src/Plugin/WebformHandler/EmailWebformHandler.php
@@ -814,7 +814,7 @@ class EmailWebformHandler extends WebformHandlerBase implements WebformHandlerMe
       '#webform_submission' => $webform_submission,
       '#handler' => $this,
     ];
-    $message['body'] = trim((string) \Drupal::service('renderer')->renderPlain($build));
+    $message['body'] =  \Drupal::service('renderer')->renderPlain($build);
 
     // Send message.
     $this->mailManager->mail('webform', 'email_' . $this->getHandlerId(), $to, $current_langcode, $message, $from);


### PR DESCRIPTION
Error: HTML emails are shown with escaped tags
--
This is because SwiftMailer verifies that the body is an object of type Drupal\Component\Render\MarkupInterface, otherwise it escapes its value

(See method: Drupal\swiftmailer\Plugin\Mail\SwiftMailer::massageMessageBody)