### PR TITLE
Input mask library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ html
 
 # Ignore all *.features.yml files.
 *.features.yml
+
+# Ignore IDE
+.idea

--- a/webform.libraries.yml
+++ b/webform.libraries.yml
@@ -989,7 +989,7 @@ libraries.jquery.inputmask:
   cdn:
     /libraries/jquery.inputmask/: https://cdn.rawgit.com/RobinHerbots/Inputmask/3.3.10/
   js:
-    /libraries/jquery.inputmask/dist/min/jquery.inputmask.bundle.min.js: {}
+    /libraries/Inputmask/dist/min/jquery.inputmask.bundle.min.js: {}
   dependencies:
     - core/jquery
 


### PR DESCRIPTION
It seems the author of the library
https://github.com/RobinHerbots/jquery.inputmask
changed its name: (
And now, when installed through the composter, it is copied into a directory called **"Inputmask"** instead of **"jquery.inputmask".**
And drupal can not find it locally.
I used **"libraries-override"** in my theme. But it seems to me not very convenient.